### PR TITLE
Py39

### DIFF
--- a/hf_rvc/models/feature_extraction_rvc.py
+++ b/hf_rvc/models/feature_extraction_rvc.py
@@ -134,9 +134,9 @@ class RVCFeatureExtractor(Wav2Vec2FeatureExtractor):
     def __call__(
         self,
         audio: np.ndarray,
-        sampling_rate: Any = None,
+        sampling_rate: int or None = None,
         f0_up_key: float = 0,
-        return_tensors: Any = None,
+        return_tensors: str or TensorType or None = None,
     ) -> BatchFeature:
         input_values = Wav2Vec2FeatureExtractor.__call__(
             self, audio, sampling_rate=sampling_rate
@@ -171,7 +171,7 @@ class RVCFeatureExtractor(Wav2Vec2FeatureExtractor):
         self._f0_extractor = F0_EXTRACTORS.get(f0_method)
 
     def _extract_f0_features(
-        self, audio: np.ndarray, f0_up_key: float = 0, p_len: Any = None
+        self, audio: np.ndarray, f0_up_key: float = 0, p_len: int or None = None
     ) -> tuple[np.ndarray, np.ndarray]:
         if p_len is None:
             p_len = audio.shape[-1] // self.window


### PR DESCRIPTION
Use `or` instead of `|` operator for compatibility with Python 3.9