### PR TITLE
Fix support for Python 3.8

### DIFF
--- a/hf_rvc/converters/convert_hubert.py
+++ b/hf_rvc/converters/convert_hubert.py
@@ -1,5 +1,5 @@
 from os import PathLike
-from typing import Any, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import torch
 from transformers import HubertConfig, HubertForCTC
@@ -36,7 +36,7 @@ def extract_hubert_config(fairseq_hubert) -> HubertConfig:
 
 def extract_hubert_state(
     config_or_model: Union[HubertConfig, HubertForCTC], fairseq_hubert
-) -> dict[str, Any]:
+) -> Dict[str, Any]:
     fairseq_state_dict = fairseq_hubert.state_dict()
     assert isinstance(fairseq_state_dict, dict)
 

--- a/hf_rvc/converters/convert_rvc.py
+++ b/hf_rvc/converters/convert_rvc.py
@@ -1,6 +1,6 @@
 from os import PathLike
 from pathlib import Path
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 from transformers import HubertConfig, HubertForCTC
 

--- a/hf_rvc/converters/convert_vits.py
+++ b/hf_rvc/converters/convert_vits.py
@@ -1,5 +1,5 @@
 from os import PathLike
-from typing import Any, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import torch
 
@@ -10,17 +10,17 @@ from ..models.vits.models import (
 from ..utils.path import remove_extension
 
 
-def load_vits_checkpoint(vits_path: Union[str, PathLike]) -> dict[str, Any]:
+def load_vits_checkpoint(vits_path: Union[str, PathLike]) -> Dict[str, Any]:
     return torch.load(vits_path, map_location="cpu", weights_only=True)
 
 
 def extract_vits_config(
-    vits_checkpoint: dict[str, Any],
+    vits_checkpoint: Dict[str, Any],
 ) -> SynthesizerTrnMs256NSFsidConfig:
     return SynthesizerTrnMs256NSFsidConfig(*vits_checkpoint["config"])
 
 
-def extract_vits_state(vits_checkpoint: dict[str, Any]) -> dict[str, Any]:
+def extract_vits_state(vits_checkpoint: Dict[str, Any]) -> Dict[str, Any]:
     def _fix_key(key: str) -> str:
         return key.replace(".gamma", ".weight").replace(".beta", ".bias")
 
@@ -28,7 +28,7 @@ def extract_vits_state(vits_checkpoint: dict[str, Any]) -> dict[str, Any]:
 
 
 def convert_vits(
-    vits_checkpoint: Union[str, PathLike, dict[str, Any]],
+    vits_checkpoint: Union[str, PathLike, Dict[str, Any]],
     save_directory: Optional[Union[str, PathLike]] = None,
     safe_serialization=True,
 ) -> SynthesizerTrnMs256NSFsid:

--- a/hf_rvc/models/configuration_rvc.py
+++ b/hf_rvc/models/configuration_rvc.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Dict
 
 from transformers import HubertConfig, PretrainedConfig
 
@@ -19,7 +19,7 @@ class RVCConfig(PretrainedConfig):
         self.hubert = hubert
         self.vits = vits
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         dict = super().to_dict()
         dict["hubert"] = self.hubert.to_dict()
         dict["vits"] = self.vits.__dict__

--- a/hf_rvc/models/feature_extraction_rvc.py
+++ b/hf_rvc/models/feature_extraction_rvc.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import numpy as np
 from transformers import Wav2Vec2FeatureExtractor
@@ -175,7 +175,7 @@ class RVCFeatureExtractor(Wav2Vec2FeatureExtractor):
         audio: np.ndarray,
         f0_up_key: float = 0,
         p_len: Optional[int] = None,
-    ) -> tuple[np.ndarray, np.ndarray]:
+    ) -> Tuple[np.ndarray, np.ndarray]:
         if p_len is None:
             p_len = audio.shape[-1] // self.window
 
@@ -209,7 +209,7 @@ class RVCFeatureExtractor(Wav2Vec2FeatureExtractor):
 
         return f0_coarse, f0bak
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         """
         Serializes this instance to a Python dictionary.
 

--- a/hf_rvc/models/vits/models.py
+++ b/hf_rvc/models/vits/models.py
@@ -3,6 +3,7 @@ import os
 import pdb
 from dataclasses import dataclass
 from time import time as ttime
+from typing import List
 
 import numpy as np
 import torch
@@ -539,11 +540,11 @@ class SynthesizerTrnMs256NSFsidConfig(PretrainedConfig):
         kernel_size: int = 3,
         p_dropout: int = 0,
         resblock: str = "1",
-        resblock_kernel_sizes: list[int] = [3, 7, 11],
-        resblock_dilation_sizes: list[list[int]] = [[1, 3, 5], [1, 3, 5], [1, 3, 5]],
-        upsample_rates: list[int] = [10, 6, 2, 2, 2],
+        resblock_kernel_sizes: List[int] = [3, 7, 11],
+        resblock_dilation_sizes: List[List[int]] = [[1, 3, 5], [1, 3, 5], [1, 3, 5]],
+        upsample_rates: List[int] = [10, 6, 2, 2, 2],
         upsample_initial_channel: int = 512,
-        upsample_kernel_sizes: list[int] = [16, 16, 4, 4, 4],
+        upsample_kernel_sizes: List[int] = [16, 16, 4, 4, 4],
         spk_embed_dim: int = 109,
         gin_channels: int = 256,
         sr: int = 48000,


### PR DESCRIPTION
This fixes support for Python 3.8 by importing `Dict`, `List`, and `Tuple` from `typing` where necessary.